### PR TITLE
HBAPP-62: Fix inference api client lib

### DIFF
--- a/components/local-chat.tsx
+++ b/components/local-chat.tsx
@@ -26,7 +26,7 @@ export const LocalChat = ({ id, initialMessages, services, className }: IProps) 
 
   return (
     <>
-      <div className={cn('pb-[200px] pt-4 md:pt-10', className)}>
+      <div className={cn('w-full pb-[200px] pt-4 md:pt-10', className)}>
         {messages.length ? (
           <>
             <ChatList messages={messages} />


### PR DESCRIPTION
The client library used for parsing responses from homebrew api and llama-cpp-python-server was parsing non-existent json for text inference endpoints.